### PR TITLE
Implemented endpoint POST /tasks/{id}:cancel

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     links:
       - mongo-protes
       - rabbit-protes
-    command: bash -c "cd /app/pro_tes; celery worker -A celery_worker -E --loglevel=info"
+    command: bash -c "cd /app/pro_tes; celery worker -A celery_worker -E --loglevel=info --statedb=/data/celery/worker.state"
     volumes:
       - ../data:/data
 

--- a/pro_tes/ga4gh/tes/endpoints/cancel_task.py
+++ b/pro_tes/ga4gh/tes/endpoints/cancel_task.py
@@ -1,15 +1,15 @@
-"""Utility functions for POST /runs/{run_id}/cancel endpoints."""
+"""Utility functions for POST /tasks/{id}:cancel endpoint."""
 
 import logging
 from typing import Dict
 
-from celery import (Celery, uuid)
+from celery import current_app
 from connexion.exceptions import Forbidden
+import tes
 
-from wes_elixir.config.config_parser import get_conf
-from wes_elixir.errors.errors import WorkflowNotFound
-from wes_elixir.ga4gh.wes.states import States
-from wes_elixir.tasks.tasks.cancel_run import task__cancel_run
+from pro_tes.config.config_parser import get_conf
+from pro_tes.errors.errors import TaskNotFound
+from pro_tes.ga4gh.tes.states import States
 
 
 # Get logger instance
@@ -19,73 +19,64 @@ logger = logging.getLogger(__name__)
 # Utility function for endpoint POST /runs/<run_id>/delete
 def cancel_run(
     config: Dict,
-    celery_app: Celery,
-    run_id: str,
+    task_id: str,
     *args,
     **kwargs
 ) -> Dict:
     """Cancels running workflow."""
-    collection_runs = get_conf(config, 'database', 'collections', 'runs')
-    document = collection_runs.find_one(
-        filter={'run_id': run_id},
+    collection = get_conf(config, 'database', 'collections', 'tasks')
+    document = collection.find_one(
+        filter={'task_id': task_id},
         projection={
+            'task_id_tes': True,
+            'tes_uri': True,
+            'task.state': True,
             'user_id': True,
-            'task_id': True,
-            'api.state': True,
+            'worker_id': True,
             '_id': False,
         }
     )
 
-    # Raise error if workflow run was not found
+    # Raise error if task was not found
     if not document:
-        logger.error("Run '{run_id}' not found.".format(run_id=run_id))
-        raise WorkflowNotFound
+        logger.error("Task '{task_id}' not found.".format(task_id=task_id))
+        raise TaskNotFound
 
     # Raise error trying to access workflow run that is not owned by user
     # Only if authorization enabled
     if 'user_id' in kwargs and document['user_id'] != kwargs['user_id']:
         logger.error(
             (
-                "User '{user_id}' is not allowed to access workflow run "
-                "'{run_id}'."
+                "User '{user_id}' is not allowed to access task '{task_id}'."
             ).format(
                 user_id=kwargs['user_id'],
-                run_id=run_id,
+                task_id=task_id,
             )
         )
         raise Forbidden
 
-    # Cancel unfinished workflow run in background
-    if document['api']['state'] in States.CANCELABLE:
+    # If task is in cancelable state...
+    if document['task']['state'] in States.CANCELABLE or \
+       document['task']['state'] in States.UNDEFINED:
 
         # Get timeout duration
-        timeout_duration = get_conf(
+        timeout = get_conf(
             config,
             'api',
             'endpoint_params',
             'timeout_cancel_run',
         )
 
-        # Execute cancelation task in background
-        task_id = uuid()
-        logger.info(
-            (
-                "Canceling run '{run_id}' as background task "
-                "'{task_id}'..."
-            ).format(
-                run_id=run_id,
-                task_id=task_id,
-            )
-        )
-        task__cancel_run.apply_async(
-            None,
-            {
-                'run_id': run_id,
-                'task_id': document['task_id'],
-            },
-            task_id=task_id,
-            soft_time_limit=timeout_duration,
-        )
+        # Cancel local task
+        current_app.control.revoke(document['worker_id'], terminate=True)
 
-    response = {'run_id': run_id}
-    return response
+        # Cancel remote task
+        if document['tes_uri'] is not None and document['task_id_tes'] is not None:
+            cli = tes.HTTPClient(document['tes_uri'], timeout=timeout)
+            cli.cancel_task(document['task_id_tes'])
+
+    # ...else raise 404 response
+    else:
+        raise TaskNotFound
+
+    return {}

--- a/pro_tes/tasks/tasks/submit_task.py
+++ b/pro_tes/tasks/tasks/submit_task.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from dateutil.parser import parse as parse_time
 import logging
-import tes
 from time import sleep
 from typing import (Dict, List, Tuple)
 
@@ -12,6 +11,7 @@ from flask import current_app
 from flask import Flask
 from flask_pymongo import PyMongo
 from pymongo import collection as Collection
+import tes
 from werkzeug.exceptions import (BadRequest, InternalServerError)
 
 from pro_tes.celery_worker import celery


### PR DESCRIPTION
**Details**

Implemented endpoint `POST /tasks/{id}:cancel` as outlined in #22. The background task on proTES is revoked by Celery, the process running it locally (i.e. on proTES) is terminated, and a cancellation request is relayed to the remote TES. Currently untested.

**Closing issues**

Closes #22 