### PR TITLE
fix: write modified specs to docker volume

### DIFF
--- a/pro_tes/app.py
+++ b/pro_tes/app.py
@@ -35,6 +35,7 @@ def run_server():
     connexion_app = register_openapi(
         app=connexion_app,
         specs=get_conf_type(config, 'api', 'specs', types=(list)),
+        spec_dir=get_conf(config, 'storage', 'spec_dir'),
         add_security_definitions=True,
     )
 

--- a/pro_tes/config/app_config.yaml
+++ b/pro_tes/config/app_config.yaml
@@ -35,6 +35,10 @@ database:
         length: 6
         charset: string.ascii_uppercase + string.digits
 
+# Storage
+storage:
+    spec_dir: 'tests/specs'
+
 # Celery task queue
 celery:
     broker_host: 'localhost'

--- a/pro_tes/config/override/app_config.dev.yaml
+++ b/pro_tes/config/override/app_config.dev.yaml
@@ -9,6 +9,10 @@ database:
     host: 'mongo-protes'
     name: pro-tes-db-dev
 
+# Storage
+storage:
+    spec_dir: '/data/specs'
+
 # Celery task queue
 celery:
     broker_host: 'rabbit-protes'


### PR DESCRIPTION
**Details**

Implementation optionally adds security definitions to TES specs. Previously, these were written to a file outside the configures storage volume that is mounted in the container. This was now fixed by adding a config parameter for the mounted volume to which the modified specs are written.