### PR TITLE
proTES TLS ingress support

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -43,6 +43,10 @@ cd proTES
 vim values.yaml
 ```
 
+NOTE: update the variable clusterType in values.yaml depending on your target cluster:
+  - For OpenShift clusters set the value to: `openshift`
+  - For plain Kubernetes clusters set the value to: `kubernetes`
+
 ### Using the Helm CLI
 
 Optionally, for CI/CD use cases for example, you could override the values in 
@@ -68,6 +72,10 @@ Once proTES is deployed, you can access it via the url endpoint which you can
 query by running:
 
 ```bash 
+# In vanilla kubernetes clusters
 kubectl get ingress
+
+# In OpenShift clusters
+kubectl get routes
 ```
 

--- a/deployment/templates/flower/flower-ingress.yaml
+++ b/deployment/templates/flower/flower-ingress.yaml
@@ -1,10 +1,32 @@
+{{- if eq .Values.clusterType "openshift" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: extensions/v1beta1
 kind: Ingress
+{{ end }}
 metadata:
   labels:
     app: {{ .Values.flower.appName }}
   name: {{ .Values.flower.appName }}
 spec:
+{{- if eq .Values.clusterType "openshift" }}
+  host: {{ .Values.flower.appName }}.{{ .Values.applicationDomain }}
+  port:
+    targetPort: 5555
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ .Values.flower.appName }}
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress: []
+{{- else }}
+  tls:
+  - hosts:
+      - {{ .Values.flower.appName }}.{{ .Values.applicationDomain }}
   rules:
   - host: {{ .Values.flower.appName }}.{{ .Values.applicationDomain }}
     http:
@@ -13,3 +35,4 @@ spec:
         backend:
           serviceName: {{ .Values.flower.appName }}
           servicePort: 5555
+{{ end }}

--- a/deployment/templates/protes/protes-ingress.yaml
+++ b/deployment/templates/protes/protes-ingress.yaml
@@ -1,10 +1,33 @@
+{{- if eq .Values.clusterType "openshift" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: extensions/v1beta1
 kind: Ingress
+{{ end }}
 metadata:
   labels:
     app: {{ .Values.protes.appName }}
   name: {{ .Values.protes.appName }}
 spec:
+{{- if eq .Values.clusterType "openshift" }}
+  host: {{ .Values.protes.appName }}.{{ .Values.applicationDomain }}
+  path: "/ga4gh/tes/v1"
+  port:
+    targetPort: 8081
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ .Values.protes.appName }}
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress: []
+{{- else }}
+  tls:
+  - hosts:
+    - {{ .Values.protes.appName }}.{{ .Values.applicationDomain }}
   rules:
   - host: {{ .Values.protes.appName }}.{{ .Values.applicationDomain }}
     http:
@@ -13,3 +36,4 @@ spec:
         backend:
           serviceName: {{ .Values.protes.appName }}
           servicePort: 8081
+{{ end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -4,6 +4,10 @@
 
 applicationDomain: c03.k8s-popup.csc.fi
 
+# which cluster type proTES is going to be deployed on
+# it can be either 'kubernetes' or 'openshift'
+clusterType: openshift
+
 flower:
   appName: flower
   basicAuth: admin:admin


### PR DESCRIPTION
Add support for TLS termination for both the flower deployment
and proTES. Helm conditionals had to be used since the Ingress
objects definitions vary depending on the Ingress controller
which is on the target cluster. For OpenShift we use Route objects
and for Kubernetes we use Ingress objects.

The cluster type is defined under values.yaml, the possible values
are either 'openshift' or 'kubernetes'.

The documentation has been updated accordingly.
