### PR TITLE
Allow to specify security definitions from configuration file

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -13,6 +13,7 @@
 * [Yacine Khettab](https://github.com/djixyacine)
 * [Risto Laurikainen](https://github.com/rlaurika)
 * [Jacek Lebioda](https://github.com/jLebioda)
+* [Roberto Preste](https://github.com/robertopreste)
 * [Kevin Sayers](https://github.com/KevinSayers)
 * [Jaroslaw Surkont](https://github.com/jsurkont)
 * [Marco Tangaro](https://github.com/mtangaro)

--- a/pro_tes/app.py
+++ b/pro_tes/app.py
@@ -36,7 +36,11 @@ def run_server():
         app=connexion_app,
         specs=get_conf_type(config, 'api', 'specs', types=(list)),
         spec_dir=get_conf(config, 'storage', 'spec_dir'),
-        add_security_definitions=True,
+        add_security_definitions=get_conf(
+            config,
+            'security',
+            'authorization_required'
+        ),
     )
 
     # Enable cross-origin resource sharing


### PR DESCRIPTION
**Details**

Closes #50 

The `add_security_definitions=True` argument of `register_openapi()` in [app.py](https://github.com/elixir-cloud-aai/proTES/blob/6a005f30bd69801d43a1469d97674befc76c796a/pro_tes/app.py#L39) was changed to `add_security_definitions=get_conf(config, 'security', 'authorization_required')`, in order to allow users to specify whether they want this option enabled or not directly from the yaml configuration file.