### PR TITLE
Bump MarkupSafe and psutil versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,13 +33,13 @@ kombu==4.2.1
 lazy-object-proxy==1.3.1
 lockfile==0.12.2
 lxml==4.2.5
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune==0.8.1
 mypy-extensions==0.4.1
 networkx==2.2
 prov==1.5.1
-psutil==5.4.7
+psutil==5.6.6
 py-tes==0.3.0
 pycparser==2.19
 PyJWT==1.6.4


### PR DESCRIPTION
- `MarkupSafe` from `1.0` to `1.1.1`
- `psutil` from `5.4.7` to `5.6.6`