### PR TITLE
build: fix broken Kubernetes deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 ##### BASE IMAGE #####
-FROM elixircloud/foca:20221107-py3.10
+FROM elixircloud/foca:20221110-py3.10
 
 ##### METADATA #####
-LABEL base.image="elixircloud/foca:20221107-py3.10"
 LABEL version="1.2"
 LABEL software="proTES"
 LABEL software.description="Flask microservice implementing the Global Alliance for Genomics and Health (GA4GH) Task Execution Service (TES) API specification as a proxy for middleware injection (e.g., task distribution logic)."

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,7 @@ COPY ./ .
 
 ## Install app
 RUN pip install -e .
+
+## Add permissions for storing updated API specification
+## (required by FOCA)
+RUN chmod -R a+rwx /app/pro_tes/api

--- a/deployment/templates/protes/celery-deployment.yaml
+++ b/deployment/templates/protes/celery-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: Always
         workingDir: '/app/pro_tes'
         command: [ 'celery' ]
-        args: [ 'worker', '-A', 'celery_worker', '-E', '--loglevel=info', '-c', '1', '-Q', 'celery' ]
+        args: [ '-A', 'celery_worker', 'worker', '-E', '--loglevel=info', '-c', '1', '-Q', 'celery' ]
         env:
         - name: MONGO_HOST
           value: {{ .Values.mongodb.appName }}

--- a/deployment/templates/protes/protes-deployment.yaml
+++ b/deployment/templates/protes/protes-deployment.yaml
@@ -13,13 +13,13 @@ spec:
         app: {{ .Values.protes.appName }}
     spec:
       initContainers:
-        - name: vol-init
-          image: busybox
-          command: [ 'mkdir' ]
-          args: [ '-p', '/data/db', '/data/specs' ]
-          volumeMounts:
-            - mountPath: /data
-              name: protes-volume
+      - name: vol-init
+        image: busybox
+        command: [ 'mkdir' ]
+        args: [ '-p', '/data/db', '/data/specs' ]
+        volumeMounts:
+        - mountPath: /data
+          name: protes-volume
       containers:
       - name: protes
         image: {{ .Values.protes.image }}
@@ -29,7 +29,7 @@ spec:
         args: [ '--log-level', 'debug', '-c', 'config.py', 'wsgi:app' ]
         env:
         - name: MONGO_HOST
-          value: {{ .Values.mongodb.appName}}
+          value: {{ .Values.mongodb.appName }}
         - name: MONGO_PORT
           value: "27017"
         - name: MONGO_USERNAME
@@ -48,7 +48,7 @@ spec:
               key: database-name
               name: {{ .Values.mongodb.appName }}
         - name: RABBIT_HOST
-          value: {{ .Values.rabbitmq.appName}}
+          value: {{ .Values.rabbitmq.appName }}
         - name: RABBIT_PORT
           value: "5672"
         livenessProbe:
@@ -71,4 +71,4 @@ spec:
       volumes:
       - name: protes-volume
         persistentVolumeClaim:
-          claimName: {{ .Values.protes.appName}}-volume
+          claimName: {{ .Values.protes.appName }}-volume

--- a/deployment/templates/protes/protes-deployment.yaml
+++ b/deployment/templates/protes/protes-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         imagePullPolicy: Always
         workingDir: '/app/pro_tes'
         command: [ 'gunicorn' ]
-        args: [ '--log-level', 'debug', '-c', 'config.py', 'wsgi:app' ]
+        args: [ '--log-level', 'debug', '-c', 'gunicorn.py', 'wsgi:app' ]
         env:
         - name: MONGO_HOST
           value: {{ .Values.mongodb.appName }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,14 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-applicationDomain: c03.k8s-popup.csc.fi
+applicationDomain: rahtiapp.fi
 
 # which cluster type proTES is going to be deployed on
 # it can be either 'kubernetes' or 'openshift'
 clusterType: openshift
 
 flower:
-  appName: flower
+  appName: protes-flower
   basicAuth: admin:admin
   image: endocode/flower
 

--- a/pro_tes/app.py
+++ b/pro_tes/app.py
@@ -15,6 +15,6 @@ def run_app(app: App) -> None:
     app.run(port=app.port)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = init_app()
     run_app(app)

--- a/pro_tes/celery_worker.py
+++ b/pro_tes/celery_worker.py
@@ -1,9 +1,9 @@
 """Entry point for Celery workers."""
 
-from foca.factories.celery_app import create_celery_app
+from pathlib import Path
 
-from pro_tes.app import init_app
+from foca import Foca
 
+foca = Foca(Path(__file__).resolve().parent / "config.yaml")
+celery = foca.create_celery_app()
 
-flask_app = init_app().app
-celery = create_celery_app(app=flask_app)

--- a/pro_tes/celery_worker.py
+++ b/pro_tes/celery_worker.py
@@ -6,4 +6,3 @@ from foca import Foca
 
 foca = Foca(Path(__file__).resolve().parent / "config.yaml")
 celery = foca.create_celery_app()
-

--- a/pro_tes/config.yaml
+++ b/pro_tes/config.yaml
@@ -133,3 +133,4 @@ tes:
   service_list:
     - "https://tesk-eu.hypatia-comp.athenarc.gr"
     - "https://csc-tesk-noauth.rahtiapp.fi"
+    - "https://tesk-na.cloud.e-infra.cz"

--- a/pro_tes/config.yaml
+++ b/pro_tes/config.yaml
@@ -6,130 +6,130 @@
 # Server configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.ServerConfig
 server:
-    host: '0.0.0.0'
-    port: 8080
-    debug: True
-    environment: development
-    testing: False
-    use_reloader: False
+  host: "0.0.0.0"
+  port: 8080
+  debug: True
+  environment: development
+  testing: False
+  use_reloader: False
 
 # Security configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.SecurityConfig
 security:
-    auth:
-        add_key_to_claims: True
-        algorithms:
-          - RS256
-        allow_expired: False
-        audience: null
-        validation_methods:
-          - userinfo
-          - public_key
-        validation_checks: any
+  auth:
+    add_key_to_claims: True
+    algorithms:
+      - RS256
+    allow_expired: False
+    audience: null
+    validation_methods:
+      - userinfo
+      - public_key
+    validation_checks: any
 
 # Database configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.DBConfig
 db:
-    host: mongodb
-    port: 27017
-    dbs:
-        taskStore:
-            collections:
-                tasks:
-                    indexes:
-                        - keys:
-                              task_id: 1
-                              worker_id: 1
-                          options:
-                            'unique': True
-                            'sparse': True
-                service_info:
-                    indexes:
-                        - keys:
-                              id: 1
+  host: mongodb
+  port: 27017
+  dbs:
+    taskStore:
+      collections:
+        tasks:
+          indexes:
+            - keys:
+                task_id: 1
+                worker_id: 1
+              options:
+                "unique": True
+                "sparse": True
+        service_info:
+          indexes:
+            - keys:
+                id: 1
 
 # API configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.APIConfig
 api:
-    specs:
-        - path:
-            - api/9e9c5aa.task_execution_service.openapi.yaml
-          add_operation_fields:
-              x-openapi-router-controller: pro_tes.ga4gh.tes.server 
-          add_security_fields:
-              x-bearerInfoFunc: app.validate_token
-          disable_auth: True
-          connexion:
-              strict_validation: True
-              # current specs have inconsistency, therefore disabling response validation
-              # see: https://github.com/ga4gh/task-execution-schemas/issues/136
-              validate_responses: False
-              options:
-                  swagger_ui: True
-                  serve_spec: True
+  specs:
+    - path:
+        - api/9e9c5aa.task_execution_service.openapi.yaml
+      add_operation_fields:
+        x-openapi-router-controller: ga4gh.tes.server
+      add_security_fields:
+        x-bearerInfoFunc: foca.security.auth.validate_token
+      disable_auth: True
+      connexion:
+        strict_validation: True
+        # current specs have inconsistency, therefore disabling response validation
+        # see: https://github.com/ga4gh/task-execution-schemas/issues/136
+        validate_responses: False
+        options:
+          swagger_ui: True
+          serve_spec: True
 
 # Logging configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.LogConfig
 log:
-    version: 1
-    disable_existing_loggers: False
-    formatters:
-        standard:
-            class: logging.Formatter
-            style: "{"
-            format: "[{asctime}: {levelname:<8}] {message} [{name}]"
-    handlers:
-        console:
-            class: logging.StreamHandler
-            level: 20
-            formatter: standard
-            stream: ext://sys.stderr
-    root:
-        level: 10
-        handlers: [console]
+  version: 1
+  disable_existing_loggers: False
+  formatters:
+    standard:
+      class: logging.Formatter
+      style: "{"
+      format: "[{asctime}: {levelname:<8}] {message} [{name}]"
+  handlers:
+    console:
+      class: logging.StreamHandler
+      level: 20
+      formatter: standard
+      stream: ext://sys.stderr
+  root:
+    level: 10
+    handlers: [console]
 
 jobs:
-    host: rabbitmq
-    port: 5672
-    backend: 'rpc://'
-    include:
-        - pro_tes.tasks.tasks.track_task_progress
+  host: rabbitmq
+  port: 5672
+  backend: 'rpc://'
+  include:
+    - pro_tes.tasks.tasks.track_task_progress
 
 # Exception configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.ExceptionConfig
 exceptions:
-    required_members: [['message'], ['code']]
-    status_member: ['code']
-    exceptions: pro_tes.exceptions.exceptions
+  required_members: [["message"], ["code"]]
+  status_member: ["code"]
+  exceptions: pro_tes.exceptions.exceptions
 
 controllers:
-    post_task:
-        db:
-            insert_attempts: 10
-        task_id:
-            charset: string.ascii_uppercase + string.digits
-            length: 6
-        timeout:
-            post: null
-            poll: 2
-            job: null
-        polling:
-            wait: 3
-            attempts: 100
-    list_tasks:
-        default_page_size: 5
-    celery:
-        monitor:
-            timeout: 0.1
-        message_maxsize: 16777216
+  post_task:
+    db:
+      insert_attempts: 10
+    task_id:
+      charset: string.ascii_uppercase + string.digits
+      length: 6
+    timeout:
+      post: null
+      poll: 2
+      job: null
+    polling:
+      wait: 3
+      attempts: 100
+  list_tasks:
+    default_page_size: 5
+  celery:
+    monitor:
+      timeout: 0.1
+    message_maxsize: 16777216
 
 serviceInfo:
-    doc: Proxy TES for distributing tasks across a list of service TES instances
-    name: proTES
-    storage:
-        - file:///path/to/local/storage
+  doc: Proxy TES for distributing tasks across a list of service TES instances
+  name: proTES
+  storage:
+    - file:///path/to/local/storage
 
 tes:
-    service_list:
-        - 'https://tesk-eu.hypatia-comp.athenarc.gr'
-        - 'https://csc-tesk-noauth.rahtiapp.fi'
+  service_list:
+    - "https://tesk-eu.hypatia-comp.athenarc.gr"
+    - "https://csc-tesk-noauth.rahtiapp.fi"

--- a/pro_tes/tasks/tasks/track_task_progress.py
+++ b/pro_tes/tasks/tasks/track_task_progress.py
@@ -8,20 +8,21 @@ from typing import (
 
 from foca.database.register_mongodb import _create_mongo_client
 from foca.models.config import Config
-from flask import (Flask, current_app)
+from flask import Flask
+from flask import current_app as current_flask_app
 import tes
 
 from pro_tes.ga4gh.tes.models import (
     TesState
 )
 from pro_tes.utils.db_utils import DbDocumentConnector
-from pro_tes.celery_worker import celery
 from pro_tes.ga4gh.tes.states import States
+from celery import current_app as current_celery_app
 
 logger = logging.getLogger(__name__)
 
 
-@celery.task(
+@current_celery_app.task(
     name='tasks.track_run_progress',
     bind=True,
     ignore_result=True,
@@ -49,7 +50,7 @@ def task__track_task_progress(
     Returns:
         Task identifier.
     """
-    foca_config: Config = current_app.config.foca
+    foca_config: Config = current_flask_app.config.foca
     controller_config: Dict = foca_config.controllers['post_task']
 
     # create database client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-foca==0.9.0
+foca==0.11.0
 gunicorn==20.1.0
 py-tes==0.4.2


### PR DESCRIPTION
- fix `celery` command as required by updating to Celery v5+
- fix circular import when registering background tasks (see https://github.com/elixir-cloud-aai/foca/issues/159) via bumping `foca` to `v0.11.0` and calling `Foca.create_celery_app()` in Celery worker entry point instead of importing from Connexion app factory
- fix entry point for `gunicorn` as required by removal of `config.py`
- add access permissions to write modified API specs as a workaorund for https://github.com/elixir-cloud-aai/foca/issues/158
- update default deployment values (`deployment/values.yaml`) for OpenShift deployment on Rahti (at CSC. Espoo, Finland)
- minor formatting changes to improve consistency between Celery worker and proTES app deployments
- enforce consistent indentation in app configuration (`pro_tes/config.yaml`)

Fixes #111 