### PR TITLE
fix: store task updates in correct schema property

### DIFF
--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -2,9 +2,7 @@
 
 import logging
 from time import sleep
-from typing import (
-    Dict,
-)
+from typing import Dict
 
 from foca.database.register_mongodb import _create_mongo_client
 from foca.models.config import Config
@@ -12,10 +10,11 @@ from flask import Flask
 from flask import current_app
 import tes
 
-from pro_tes.ga4gh.tes.models import TesState
+from pro_tes.ga4gh.tes.models import TesState, TesTask
 from pro_tes.utils.db import DbDocumentConnector
 from pro_tes.ga4gh.tes.states import States
 from pro_tes.celery_worker import celery
+from pro_tes.utils.models import TaskModelConverter
 
 logger = logging.getLogger(__name__)
 
@@ -75,8 +74,6 @@ def task__track_task_progress(
     except Exception:
         db_client.update_task_state(state=TesState.SYSTEM_ERROR.value)
         raise
-    response = response.as_dict()
-    db_client.upsert_fields_in_root_object(root="task_log", **response)
 
     # track task progress
     task_state: TesState = TesState.UNKNOWN
@@ -99,5 +96,6 @@ def task__track_task_progress(
             db_client.update_task_state(state=str(task_state))
 
     # final update of database after task is Finished
-    response = response.as_dict()
-    db_client.upsert_fields_in_root_object(root="task_log", **response)
+    task_model_converter = TaskModelConverter(task=response)
+    task_converted: TesTask = task_model_converter.convert_task()
+    db_client.upsert_fields_in_root_object(root="task_outgoing", **task_converted.dict())

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -27,11 +27,11 @@ logger = logging.getLogger(__name__)
     track_started=True,
 )
 def task__track_task_progress(
-        self,  # pylint: disable=unused-argument
-        worker_id: str,
-        remote_host: str,
-        remote_base_path: str,
-        remote_task_id: str,
+    self,  # pylint: disable=unused-argument
+    worker_id: str,
+    remote_host: str,
+    remote_base_path: str,
+    remote_task_id: str,
 ) -> None:
     """Relay task run request to remote TES and track run progress.
 
@@ -100,5 +100,5 @@ def task__track_task_progress(
     task_model_converter = TaskModelConverter(task=response)
     task_converted: TesTask = task_model_converter.convert_task()
     db_client.upsert_fields_in_root_object(
-        root="task_outgoing",
-        **task_converted.dict())
+        root="task_outgoing", **task_converted.dict()
+    )

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -98,4 +98,6 @@ def task__track_task_progress(
     # final update of database after task is Finished
     task_model_converter = TaskModelConverter(task=response)
     task_converted: TesTask = task_model_converter.convert_task()
-    db_client.upsert_fields_in_root_object(root="task_outgoing", **task_converted.dict())
+    db_client.upsert_fields_in_root_object(
+        root="task_outgoing",
+        **task_converted.dict())

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -19,6 +19,7 @@ from pro_tes.utils.models import TaskModelConverter
 logger = logging.getLogger(__name__)
 
 
+# pylint: disable-msg=too-many-locals
 @celery.task(
     name="tasks.track_run_progress",
     bind=True,
@@ -26,11 +27,11 @@ logger = logging.getLogger(__name__)
     track_started=True,
 )
 def task__track_task_progress(
-    self,  # pylint: disable=unused-argument
-    worker_id: str,
-    remote_host: str,
-    remote_base_path: str,
-    remote_task_id: str,
+        self,  # pylint: disable=unused-argument
+        worker_id: str,
+        remote_host: str,
+        remote_base_path: str,
+        remote_task_id: str,
 ) -> None:
     """Relay task run request to remote TES and track run progress.
 


### PR DESCRIPTION
Fixed background task progress by storing the output of the task at the correct root which is "task_outgoing".