### PR TITLE
fix: return internal task ID & refactor db model

### DIFF
--- a/pro_tes/ga4gh/tes/server.py
+++ b/pro_tes/ga4gh/tes/server.py
@@ -43,9 +43,13 @@ def CreateTask(*args, **kwargs) -> Dict:
         **kwargs: Arbitrary keyword arguments.
     """
     task_distributor = TaskDistributionMiddleware()
-    requests = task_distributor.modify_request(request=request)
+    requests, start_time = task_distributor.modify_request(request=request)
     task_runs = TaskRuns()
-    response = task_runs.create_task(request=requests, **kwargs)
+    response = task_runs.create_task(
+        request=requests,
+        start_time=start_time,
+        **kwargs
+    )
     return response
 
 

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -28,6 +28,7 @@ from pro_tes.utils.models import TaskModelConverter
 
 # pragma pylint: disable=invalid-name,redefined-builtin,unused-argument
 # pragma pylint: disable=too-many-locals
+# pylint: disable=unsubscriptable-object
 
 logger = logging.getLogger(__name__)
 

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -18,7 +18,9 @@ import tes
 from tes.models import Task
 
 from pro_tes.exceptions import BadRequest, TaskNotFound
-from pro_tes.ga4gh.tes.models import DbDocument, TesEndpoint, TesState, TesTask
+from pro_tes.ga4gh.tes.models import (
+    DbDocument, TesEndpoint, TesState, TesTask, TesTaskLog
+)
 from pro_tes.ga4gh.tes.states import States
 from pro_tes.tasks.track_task_progress import task__track_task_progress
 from pro_tes.utils.db import DbDocumentConnector
@@ -52,7 +54,7 @@ class TaskRuns:
 
         Args:
             **kwargs: Additional keyword arguments passed along with
-                             request.
+                             request and start_time.
         Returns:
             Task identifier.
         """
@@ -62,15 +64,13 @@ class TaskRuns:
         tes_uri_list = deepcopy(payload["tes_uri"])
         del payload["tes_uri"]
 
+        db_document.task_outgoing = TesTask(**payload)
         db_document.task_incoming = TesTask(**payload)
-        db_document.task_incoming.state = TesState.UNKNOWN
-        db_document.user_id = kwargs.get("user_id", None)
-
-        (task_id, worker_id) = self._write_doc_to_db(document=db_document)
-
-        db_document.task_incoming.id = task_id
-        db_document.worker_id = worker_id
-
+        db_document = self._update_task_incoming(
+            payload=payload,
+            db_document=db_document,
+            **kwargs
+        )
         url: str = (
             f"{db_document.tes_endpoint.host.rstrip('/')}/"
             f"{db_document.tes_endpoint.base_path.lstrip('/')}"
@@ -118,7 +118,7 @@ class TaskRuns:
                 continue
 
             try:
-                task_id = cli.create_task(payload_marshalled)
+                remote_task_id = cli.create_task(payload_marshalled)
             except requests.HTTPError as exc:
                 db_connector.update_task_state(
                     state=TesState.SYSTEM_ERROR.value
@@ -133,18 +133,16 @@ class TaskRuns:
                 continue
 
             logger.info(
-                f"Task '{db_document.task_incoming.id}' "
+                f"Task '{remote_task_id}' "
                 f"forwarded to TES endpoint "
-                f"hosted at: {url}. proTES task identifier: {task_id}."
+                f"hosted at: {url}. proTES task identifier: "
+                f"{db_document.task_incoming.id}."
             )
             try:
-                task: Task = cli.get_task(task_id)
+                task: Task = cli.get_task(remote_task_id)
                 task_model_converter = TaskModelConverter(task=task)
                 task_converted: TesTask = task_model_converter.convert_task()
-                db_document = db_connector.upsert_fields_in_root_object(
-                    root="task_outgoing",
-                    **task_converted.dict(),
-                )
+                db_document.task_incoming.state = task_converted.state
             except requests.HTTPError as exc:
                 logger.error(
                     f"Task '{db_document.task_incoming.id}' info could "
@@ -159,14 +157,10 @@ class TaskRuns:
                     f"sent to TES endpoint hosted at: {url}. "
                     f"Original error message:'{type(exc).__name__}: {exc}'"
                 )
-            tes_endpoint_dict = {'host': tes_uri, 'base_path': ''}
-            db_document = db_connector.upsert_fields_in_root_object(
-                root="tes_endpoint",
-                **tes_endpoint_dict,
-            )
-            logger.info(
-                f"TES endpoint: '{db_document.tes_endpoint.host}' "
-                f"finally to database "
+            db_document = self._update_doc_in_db(
+                db_connector=db_connector,
+                tes_uri=tes_uri,
+                remote_task_id=remote_task_id,
             )
             task__track_task_progress.apply_async(
                 None,
@@ -174,10 +168,10 @@ class TaskRuns:
                     "worker_id": db_document.worker_id,
                     "remote_host": db_document.tes_endpoint.host,
                     "remote_base_path": db_document.tes_endpoint.base_path,
-                    "remote_task_id": db_document.task_outgoing.id,
+                    "remote_task_id": remote_task_id,
                 },
             )
-            return {"id": task_id}
+            return {"id": db_document.task_incoming.id}
 
     def list_tasks(self, **kwargs) -> Dict:
         """Return list of tasks.
@@ -209,6 +203,7 @@ class TaskRuns:
         )
         tasks_list = list(cursor)
 
+        logger.info(f"Tasks list: {tasks_list}")
         if tasks_list:
             next_page_token = str(tasks_list[-1]["_id"])
         else:
@@ -218,13 +213,13 @@ class TaskRuns:
         for task in tasks_list:
             del task["_id"]
             if view == "MINIMAL":
-                task["id"] = task["task_outgoing"]["id"]
-                task["state"] = task["task_outgoing"]["state"]
+                task["id"] = task["task_incoming"]["id"]
+                task["state"] = task["task_incoming"]["state"]
                 tasks_lists.append({"id": task["id"], "state": task["state"]})
             if view == "BASIC":
-                tasks_lists.append(task["task_outgoing"])
+                tasks_lists.append(task["task_incoming"])
             if view == "FULL":
-                tasks_lists.append(task["task_outgoing"])
+                tasks_lists.append(task["task_incoming"])
 
         return {"next_page_token": next_page_token, "tasks": tasks_lists}
 
@@ -245,12 +240,12 @@ class TaskRuns:
         """
         projection = self._set_projection(view=kwargs.get("view", "BASIC"))
         document = self.db_client.find_one(
-            filter={"task_outgoing.id": id}, projection=projection
+            filter={"task_incoming.id": id}, projection=projection
         )
         if document is None:
             logger.error(f"Task '{id}' not found.")
             raise TaskNotFound
-        return document["task_outgoing"]
+        return document["task_incoming"]
 
     def cancel_task(self, id: str, **kwargs) -> Dict:
         """Cancel task.
@@ -269,7 +264,7 @@ class TaskRuns:
                 available.
         """
         document = self.db_client.find_one(
-            filter={"task_outgoing.id": id},
+            filter={"task_incoming.id": id},
             projection={"_id": False},
         )
         if document is None:
@@ -277,7 +272,7 @@ class TaskRuns:
             raise TaskNotFound
         db_document = DbDocument(**document)
 
-        if db_document.task_outgoing.state in States.CANCELABLE:
+        if db_document.task_incoming.state in States.CANCELABLE:
             db_connector = DbDocumentConnector(
                 collection=self.db_client,
                 worker_id=db_document.worker_id,
@@ -286,15 +281,19 @@ class TaskRuns:
                 f"{db_document.tes_endpoint.host.rstrip('/')}/"
                 f"{db_document.tes_endpoint.base_path.strip('/')}"
             )
+            task_id = db_document.task_incoming.logs[0].metadata[
+                "remote_task_id"
+            ]
             logger.warning(f"DB document: {db_document}")
             logger.info(
                 "Trying cancel task with task identifier"
-                f" '{db_document.task_outgoing.id}' and worker job"
+                f" '{task_id}' and worker job"
                 f" identifier '{db_document.worker_id}' running at TES"
                 f" endpoint hosted at: {url}"
             )
             cli = tes.HTTPClient(url, timeout=5)
-            cli.cancel_task(task_id=db_document.task_outgoing.id)
+
+            cli.cancel_task(task_id=task_id)
             db_connector.update_task_state(
                 state="CANCELED",
             )
@@ -362,19 +361,10 @@ class TaskRuns:
                 tes.models.Executor(**executor)
                 for executor in payload["executors"]
             ]
-        for log in payload.get("logs", []):
-            log["start_time"] = time_now
-            log["end_time"] = time_now
-            log["logs"] = [
-                tes.models.ExecutorLog(**log) for log in log["logs"]
+        if "logs" in payload:
+            payload["logs"] = [
+                tes.models.TaskLog(**log) for log in payload["logs"]
             ]
-            if "outputs" in log:
-                for output in log["outputs"]:
-                    output["size_bytes"] = 0
-                log["outputs"] = [
-                    tes.models.OutputFileLog(**log)
-                    for log in log["system_logs"]
-                ]
         return payload
 
     def _set_projection(self, view: str) -> Dict:
@@ -391,15 +381,15 @@ class TaskRuns:
         """
         if view == "MINIMAL":
             projection = {
-                "task_outgoing.id": True,
-                "task_outgoing.state": True,
+                "task_incoming.id": True,
+                "task_incoming.state": True,
             }
         elif view == "BASIC":
             projection = {
-                "task_outgoing.inputs.content": False,
-                "task_outgoing.system_logs": False,
-                "task_outgoing.logs.stdout": False,
-                "task_outgoing.logs.stderr": False,
+                "task_incoming.inputs.content": False,
+                "task_incoming.system_logs": False,
+                "task_incoming.logs.stdout": False,
+                "task_incoming.logs.stderr": False,
                 "tes_endpoint": False,
             }
         elif view == "FULL":
@@ -410,3 +400,80 @@ class TaskRuns:
         else:
             raise BadRequest
         return projection
+
+    def _update_task_incoming(
+        self,
+        payload: dict,
+        db_document: DbDocument,
+        **kwargs
+    ) -> DbDocument:
+        """Update the task incoming object."""
+        logs = self._set_logs(
+            payloads=deepcopy(payload),
+            start_time=kwargs["start_time"]
+        )
+        db_document.task_incoming.logs = [
+            TesTaskLog(**logs) for logs in logs
+        ]
+        db_document.task_incoming.state = TesState.UNKNOWN
+        db_document.user_id = kwargs.get("user_id", None)
+
+        (task_id, worker_id) = self._write_doc_to_db(document=db_document)
+        db_document.task_incoming.id = task_id
+        db_document.worker_id = worker_id
+        return db_document
+
+    def _set_logs(self, payloads: dict, start_time: str) -> Dict:
+        """Set up the logs for the incoming request."""
+        if "logs" not in payloads.keys():
+            logs = [{
+                'logs': [],
+                'metadata': {},
+                'start_time': start_time,
+                'end_time': None,
+                'outputs': [],
+                'system_logs': []
+            }]
+            payloads["logs"] = logs
+        else:
+            for log in payloads["logs"]:
+                log["start_time"] = start_time
+        return payloads['logs']
+
+    def _update_doc_in_db(
+            self,
+            db_connector,
+            tes_uri: str,
+            remote_task_id: str,
+    ) -> DbDocument:
+        """Update the document in the database."""
+        time_now = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
+        tes_endpoint_dict = {'host': tes_uri, 'base_path': ''}
+        db_document = db_connector.upsert_fields_in_root_object(
+            root="tes_endpoint",
+            **tes_endpoint_dict,
+        )
+        logger.info(
+            f"TES endpoint: '{db_document.tes_endpoint.host}' "
+            f"finally to database "
+        )
+        # updating the end time in TesTask logs
+        for logs in db_document.task_incoming.logs:
+            logs.end_time = time_now
+
+        # updating the metadata in TesTask logs
+        for logs in db_document.task_incoming.logs:
+            logs.metadata = {
+                "tes_uri": tes_uri,
+                "remote_task_id": remote_task_id
+            }
+
+        db_document = db_connector.upsert_fields_in_root_object(
+            root="task_incoming",
+            **db_document.dict()["task_incoming"],
+        )
+        logger.info(
+            f"Task '{db_document.task_incoming}' "
+            f"inserted to database "
+        )
+        return db_document

--- a/pro_tes/middleware/middleware.py
+++ b/pro_tes/middleware/middleware.py
@@ -1,7 +1,7 @@
 """Middleware to inject into TES requests."""
 
 import abc
-from typing import Dict
+from datetime import datetime
 
 from pro_tes.middleware.task_distribution import distance, random
 
@@ -28,8 +28,10 @@ class TaskDistributionMiddleware(AbstractMiddleware):
         self.tes_uri = []
         self.input_uri = []
 
-    def modify_request(self, request) -> Dict:
+    def modify_request(self, request):
         """Add the best possible TES instance to request body."""
+        start_time = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
+
         if "inputs" in request.json.keys():
             for index in range(len(request.json["inputs"])):
                 if "url" in request.json["inputs"][index].keys():
@@ -46,4 +48,4 @@ class TaskDistributionMiddleware(AbstractMiddleware):
             request.json["tes_uri"] = self.tes_uri
         else:
             raise Exception
-        return request
+        return request, start_time

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 # pylint: disable-msg=too-many-locals
+# pylint: disable=unsubscriptable-object
 @celery.task(
     name="tasks.track_run_progress",
     bind=True,

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -96,9 +96,18 @@ def task__track_task_progress(
             task_state = response.state
             db_client.update_task_state(state=str(task_state))
 
-    # final update of database after task is Finished
     task_model_converter = TaskModelConverter(task=response)
     task_converted: TesTask = task_model_converter.convert_task()
+
+    document = db_client.get_document()
+
+    # updating task_incoming after task is finished
+    document.task_incoming.state = task_converted.state
+    for index, logs in enumerate(task_converted.logs):
+        document.task_incoming.logs[index].logs = logs.logs
+        document.task_incoming.logs[index].outputs = logs.outputs
+
+    # updating the database
     db_client.upsert_fields_in_root_object(
-        root="task_outgoing", **task_converted.dict()
+        root="task_incoming", **document.task_incoming.dict()
     )

--- a/pro_tes/utils/db.py
+++ b/pro_tes/utils/db.py
@@ -82,7 +82,7 @@ class DbDocumentConnector:
             raise ValueError(f"Unknown state: {state}") from exc
         self.collection.find_one_and_update(
             {"worker_id": self.worker_id},
-            {"$set": {"task_log.state": state}},
+            {"$set": {"task_incoming.state": state}},
         )
         logger.info(f"[{self.worker_id}] {state}")
 


### PR DESCRIPTION
1. Fixed #122 
2. Now the proTES task id is returned instead of the remote task id ( Actual TES id where the task is executed).
3. Modified task_incoming logs in such a way that logs (that is, outputs and TES Executor logs) are updated from Actual TES, and the rest of the things (start_time, end_time, etc) are updated from the proTES.
4. Currently the information about the TES URI (where the task is submitted) and remote task id is stored in task incoming logs ( inside metadata), it is not the best way but it was essential to do this now because the endpoint `POST /tasks/{id}:cancel` relies on remote task id, this could be further fixed in #123 