### PR TITLE
fix: return execution trace in task log

### DIFF
--- a/pro_tes/api/additional_logs.yaml
+++ b/pro_tes/api/additional_logs.yaml
@@ -1,0 +1,26 @@
+components:
+  schemas:
+    tesTaskLog:
+        properties:
+          metadata:
+            properties:
+              forwarded_to:
+                $ref: '#/components/schemas/tesNextTes'
+                description: TaskLog describes logging information related to a Task.
+    tesNextTes:
+      required:
+        - url
+        - id
+      type: object
+      properties:
+        url:
+          type: string
+          description: TES server to which the task was forwarded.
+          example: https://my.tes.instance/
+        id:
+          type: string
+          description: Task identifier assigned by the TES server to which the task was forwarded.
+          example: job-0012345
+        forwarded_to:
+          $ref: '#/components/schemas/tesNextTes'
+      description: Describes the TES server to which the task was forwarded, if applicable.

--- a/pro_tes/config.yaml
+++ b/pro_tes/config.yaml
@@ -54,6 +54,7 @@ api:
   specs:
     - path:
         - api/9e9c5aa.task_execution_service.openapi.yaml
+        - api/additional_logs.yaml
       add_operation_fields:
         x-openapi-router-controller: ga4gh.tes.server
       add_security_fields:
@@ -134,3 +135,6 @@ tes:
     - "https://tesk-eu.hypatia-comp.athenarc.gr"
     - "https://csc-tesk-noauth.rahtiapp.fi"
     - "https://tesk-na.cloud.e-infra.cz"
+
+storeLogs:
+  execution_trace: True

--- a/pro_tes/ga4gh/tes/models.py
+++ b/pro_tes/ga4gh/tes/models.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
+# pragma pylint: disable=no-name-in-module
 from pydantic import AnyUrl, BaseModel, Field
 
 # pragma pylint: disable=too-few-public-methods
@@ -418,16 +419,40 @@ class TesState(Enum):
     CANCELED = "CANCELED"
 
 
+class TesNextTes(BaseModel):
+    """Create model instance for next TESNextTes."""
+
+    url: str = Field(
+        ...,
+        description="TES server to which the task was forwarded.",
+        example="https://my.tes.instance/",
+    )
+    id: str = Field(
+        ...,
+        description="Task identifier assigned by the "
+        "TES server to which the task was forwarded.",
+        example="job-0012345",
+    )
+    forwarded_to: Optional[TesNextTes] = None
+
+
+class Metadata(BaseModel):
+    """Create model instance for metadata."""
+
+    forwarded_to: Optional[TesNextTes] = Field(
+        None, description="TaskLog describes logging "
+                          "information related to a Task"
+    )
+
+
 class TesTaskLog(BaseModel):
     logs: List[TesExecutorLog] = Field(
-        ..., description="Logs for each         executor"
+        ..., description="Logs for each executor"
     )
-    metadata: Optional[Dict[str, str]] = Field(
+    metadata: Optional[Metadata] = Field(
         None,
-        description=(
-            "Arbitrary logging metadata included by the            "
-            " implementation."
-        ),
+        description="Arbitrary logging metadata"
+                    "included by the implementation.",
         example={"host": "worker-001", "slurmm_id": 123456},
     )
     start_time: Optional[str] = Field(
@@ -659,3 +684,6 @@ class DbDocument(BaseModel):
         """Pydantic configuration for model."""
 
         use_enum_values = True
+
+
+TesNextTes.update_forward_refs()

--- a/pro_tes/middleware/middleware.py
+++ b/pro_tes/middleware/middleware.py
@@ -47,5 +47,5 @@ class TaskDistributionMiddleware(AbstractMiddleware):
         if len(self.tes_uri) != 0:
             request.json["tes_uri"] = self.tes_uri
         else:
-            raise Exception
+            raise Exception  # pragma pylint: disable=broad-exception-raised
         return request, start_time


### PR DESCRIPTION
- Fixed #123 
- Updated schema by nesting the TesNextTes inside the metadata of the TesTaskLog.
- Added param in the config file if set to true the remote_tes_id and TES URL (where the task is executed) is stored in log metadata to trace the execution of the task.
