### PR TITLE
Basic auth for TES and inputs/outputs; bug in enum serialization

### DIFF
--- a/pro_tes/config.yaml
+++ b/pro_tes/config.yaml
@@ -132,9 +132,11 @@ serviceInfo:
 
 tes:
   service_list:
-    - "https://tesk-eu.hypatia-comp.athenarc.gr"
     - "https://csc-tesk-noauth.rahtiapp.fi"
+    - "https://funnel.cloud.e-infra.cz/"
+    - "https://tesk-eu.hypatia-comp.athenarc.gr"
     - "https://tesk-na.cloud.e-infra.cz"
+    - "https://vm4816.kaj.pouta.csc.fi/"
 
 storeLogs:
   execution_trace: True

--- a/pro_tes/ga4gh/tes/models.py
+++ b/pro_tes/ga4gh/tes/models.py
@@ -19,15 +19,24 @@ from pydantic import AnyUrl, BaseModel, Field
 # pragma pylint: disable=too-few-public-methods
 
 
-class TesCancelTaskResponse(BaseModel):
+class CustomBaseModel(BaseModel):
+    """Base model that all other models derive from."""
+
+    class Config:
+        """Configuration class."""
+
+        use_enum_values = True
+
+
+class TesCancelTaskResponse(CustomBaseModel):
     pass
 
 
-class TesCreateTaskResponse(BaseModel):
+class TesCreateTaskResponse(CustomBaseModel):
     id: str = Field(..., description="Task identifier assigned by the server.")
 
 
-class TesExecutor(BaseModel):
+class TesExecutor(CustomBaseModel):
     image: str = Field(
         [""],
         description=(
@@ -104,7 +113,7 @@ class TesExecutor(BaseModel):
     )
 
 
-class TesExecutorLog(BaseModel):
+class TesExecutorLog(CustomBaseModel):
     start_time: Optional[str] = Field(
         None,
         description="Time the executor started, in RFC 3339 format.",
@@ -151,7 +160,7 @@ class TesFileType(Enum):
     DIRECTORY = "DIRECTORY"
 
 
-class TesInput(BaseModel):
+class TesInput(CustomBaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     url: Optional[str] = Field(
@@ -184,7 +193,7 @@ class TesInput(BaseModel):
     )
 
 
-class TesOutput(BaseModel):
+class TesOutput(CustomBaseModel):
     name: Optional[str] = Field(
         None, description="User-provided name of         output file"
     )
@@ -214,7 +223,7 @@ class TesOutput(BaseModel):
     type: TesFileType
 
 
-class TesOutputFileLog(BaseModel):
+class TesOutputFileLog(CustomBaseModel):
     url: str = Field(
         ...,
         description=(
@@ -239,7 +248,7 @@ class TesOutputFileLog(BaseModel):
     )
 
 
-class TesResources(BaseModel):
+class TesResources(CustomBaseModel):
     cpu_cores: Optional[int] = Field(
         None, description="Requested number of CPUs", example=4
     )
@@ -277,7 +286,7 @@ class Artifact(Enum):
     tes = "tes"
 
 
-class ServiceType(BaseModel):
+class ServiceType(CustomBaseModel):
     group: str = Field(
         ...,
         description=(
@@ -310,7 +319,7 @@ class ServiceType(BaseModel):
     )
 
 
-class Organization(BaseModel):
+class Organization(CustomBaseModel):
     name: str = Field(
         ...,
         description="Name of the organization responsible for the service",
@@ -323,7 +332,7 @@ class Organization(BaseModel):
     )
 
 
-class Service(BaseModel):
+class Service(CustomBaseModel):
     id: str = Field(
         ...,
         description=(
@@ -423,7 +432,7 @@ class TesState(Enum):
     CANCELED = "CANCELED"
 
 
-class TesNextTes(BaseModel):
+class TesNextTes(CustomBaseModel):
     """Create model instance for next TESNextTes."""
 
     url: str = Field(
@@ -442,7 +451,7 @@ class TesNextTes(BaseModel):
     forwarded_to: Optional[TesNextTes] = None
 
 
-class Metadata(BaseModel):
+class Metadata(CustomBaseModel):
     """Create model instance for metadata."""
 
     forwarded_to: Optional[TesNextTes] = Field(
@@ -451,7 +460,7 @@ class Metadata(BaseModel):
     )
 
 
-class TesTaskLog(BaseModel):
+class TesTaskLog(CustomBaseModel):
     logs: List[TesExecutorLog] = Field(
         ..., description="Logs for each executor"
     )
@@ -514,7 +523,7 @@ class TesServiceInfo(Service):
     type: Optional[TesServiceType] = None
 
 
-class TesTask(BaseModel):
+class TesTask(CustomBaseModel):
     id: Optional[str] = Field(
         None,
         description="Task identifier assigned by the server.",
@@ -615,7 +624,7 @@ class TesTask(BaseModel):
         use_enum_values = True
 
 
-class TesListTasksResponse(BaseModel):
+class TesListTasksResponse(CustomBaseModel):
     tasks: List[TesTask] = Field(
         ...,
         description=(
@@ -635,7 +644,7 @@ class TesListTasksResponse(BaseModel):
     )
 
 
-class BasicAuth(BaseModel):
+class BasicAuth(CustomBaseModel):
     """Model instance for basic authorization credentials.
 
     Args:
@@ -651,7 +660,7 @@ class BasicAuth(BaseModel):
     password: Optional[str] = None
 
 
-class TesEndpoint(BaseModel):
+class TesEndpoint(CustomBaseModel):
     """Create model instance for external TES endpoint.
 
     Args:
@@ -679,7 +688,7 @@ class TesEndpoint(BaseModel):
     base_path: str = ""
 
 
-class DbDocument(BaseModel):
+class DbDocument(CustomBaseModel):
     """Create model instance for task request database document.
 
     Args:

--- a/pro_tes/ga4gh/tes/models.py
+++ b/pro_tes/ga4gh/tes/models.py
@@ -139,7 +139,11 @@ class TesExecutorLog(BaseModel):
             " Task.outputs to upload that file\nto permanent storage."
         ),
     )
-    exit_code: int = Field(..., description="Exit code.")
+    # exit code not optional according to specs, but Funnel may return 'null'
+    exit_code: Optional[int] = Field(
+        None,
+        description="Exit code.",
+    )
 
 
 class TesFileType(Enum):
@@ -429,8 +433,10 @@ class TesNextTes(BaseModel):
     )
     id: str = Field(
         ...,
-        description="Task identifier assigned by the "
-        "TES server to which the task was forwarded.",
+        description=(
+            "Task identifier assigned by the "
+            "TES server to which the task was forwarded."
+        ),
         example="job-0012345",
     )
     forwarded_to: Optional[TesNextTes] = None
@@ -440,8 +446,8 @@ class Metadata(BaseModel):
     """Create model instance for metadata."""
 
     forwarded_to: Optional[TesNextTes] = Field(
-        None, description="TaskLog describes logging "
-                          "information related to a Task"
+        None,
+        description="TaskLog describes logging information related to a Task",
     )
 
 
@@ -451,8 +457,9 @@ class TesTaskLog(BaseModel):
     )
     metadata: Optional[Metadata] = Field(
         None,
-        description="Arbitrary logging metadata"
-                    "included by the implementation.",
+        description=(
+            "Arbitrary logging metadataincluded by the implementation."
+        ),
         example={"host": "worker-001", "slurmm_id": 123456},
     )
     start_time: Optional[str] = Field(
@@ -628,6 +635,22 @@ class TesListTasksResponse(BaseModel):
     )
 
 
+class BasicAuth(BaseModel):
+    """Model instance for basic authorization credentials.
+
+    Args:
+        username: Username for basic authorization.
+        password: Password for basic authorization.
+
+    Attributes:
+        username: Username for basic authorization.
+        password: Password for basic authorization.
+    """
+
+    username: Optional[str] = None
+    password: Optional[str] = None
+
+
 class TesEndpoint(BaseModel):
     """Create model instance for external TES endpoint.
 
@@ -664,6 +687,7 @@ class DbDocument(BaseModel):
         task_outgoing: Information about outgoing task.
         user_id: Identifier of resource owner.
         worker_id: Identifier of worker task.
+        basic_auth: Basic authentication credentials.
         tes_endpoint: External TES endpoint.
 
     Attributes:
@@ -671,6 +695,7 @@ class DbDocument(BaseModel):
         task_outgoing: Information about outgoing task.
         user_id: Identifier of resource owner.
         worker_id: Identifier of worker task.
+        basic_auth: Basic authentication credentials.
         tes_endpoint: External TES endpoint.
     """
 
@@ -678,6 +703,7 @@ class DbDocument(BaseModel):
     task_outgoing: TesTask = TesTask(executors=[])
     user_id: Optional[str] = None
     worker_id: str = ""
+    basic_auth: BasicAuth = BasicAuth()
     tes_endpoint: TesEndpoint = TesEndpoint()
 
     class Config:

--- a/pro_tes/ga4gh/tes/server.py
+++ b/pro_tes/ga4gh/tes/server.py
@@ -46,9 +46,7 @@ def CreateTask(*args, **kwargs) -> Dict:
     requests, start_time = task_distributor.modify_request(request=request)
     task_runs = TaskRuns()
     response = task_runs.create_task(
-        request=requests,
-        start_time=start_time,
-        **kwargs
+        request=requests, start_time=start_time, **kwargs
     )
     return response
 

--- a/pro_tes/middleware/middleware.py
+++ b/pro_tes/middleware/middleware.py
@@ -57,5 +57,5 @@ class TaskDistributionMiddleware(AbstractMiddleware):
         if len(self.tes_uris) != 0:
             request.json["tes_uri"] = self.tes_uris
         else:
-            raise Exception  # pragma pylint: disable=broad-exception-raised
+            raise Exception  # pylint: disable=broad-exception-raised
         return request, start_time

--- a/pro_tes/middleware/task_distribution/distance.py
+++ b/pro_tes/middleware/task_distribution/distance.py
@@ -2,8 +2,9 @@
 
 from copy import deepcopy
 from itertools import combinations
+import logging
 from socket import gaierror, gethostbyname
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Set, Tuple
 from urllib.parse import urlparse
 
 from flask import current_app
@@ -17,8 +18,6 @@ from pro_tes.middleware.models import (
     TesDeployment,
     TesStats,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/pro_tes/middleware/task_distribution/distance.py
+++ b/pro_tes/middleware/task_distribution/distance.py
@@ -37,7 +37,6 @@ def task_distribution(input_uri: List) -> List:
     """
     foca_conf = current_app.config.foca
     tes_uri: List[str] = deepcopy(foca_conf.tes["service_list"])
-    logger.warning("TES URI: %s", tes_uri)
     access_uri_combination = get_uri_combination(input_uri, tes_uri)
 
     # get the combination of the tes ip and input ip
@@ -59,10 +58,9 @@ def task_distribution(input_uri: List) -> List:
     # access URI combination
     for index, value in enumerate(access_uri_combination.tes_deployments):
         value.stats.total_distance = distances[index]["total"]
+    logger.info(f"access_uri_combination: {access_uri_combination}")
 
-    ranked_tes_uris = rank_tes_instances(access_uri_combination)
-
-    return ranked_tes_uris
+    return rank_tes_instances(access_uri_combination)
 
 
 def get_uri_combination(

--- a/pro_tes/middleware/task_distribution/random.py
+++ b/pro_tes/middleware/task_distribution/random.py
@@ -2,29 +2,18 @@
 
 import random
 from copy import deepcopy
-from typing import List, Optional
+from typing import List
 
-import requests
 from flask import current_app
 
 
-def task_distribution() -> Optional[List]:
-    """Random task distributor.
-
-    Randomly distribute tasks across available TES instances.
+def task_distribution() -> List[str]:
+    """Randomize list of TES instances.
 
     Returns:
-        A randomly selected, available TES instance.
+        Randomly shuffled list of TES instances.
     """
     foca_conf = current_app.config.foca
     tes_uri: List[str] = deepcopy(foca_conf.tes["service_list"])
-    timeout: int = foca_conf.controllers["post_task"]["timeout"]["poll"]
-    while len(tes_uri) != 0:
-        random_tes_uri: str = random.choice(tes_uri)
-        response = requests.get(url=random_tes_uri, timeout=timeout)
-        if response.status_code == 200:
-            tes_uri.clear()
-            tes_uri.insert(0, random_tes_uri)
-            return tes_uri
-        tes_uri.remove(random_tes_uri)
-    return []
+    random.shuffle(tes_uri)
+    return tes_uri

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -33,10 +33,13 @@ def task__track_task_progress(
     remote_host: str,
     remote_base_path: str,
     remote_task_id: str,
+    user: str,
+    password: str,
 ) -> None:
     """Relay task run request to remote TES and track run progress.
 
     Args:
+        worker_id: Worker identifier.
         remote_host: Host at which the TES API is served that is processing
             this request; note that this should include the path information
             but *not* the base path defined in the TES API specification;
@@ -45,6 +48,8 @@ def task__track_task_progress(
         remote_base_path: Override the default path suffix defined in the tes
             API specification, i.e., `/ga4gh/tes/v1`.
         remote_task_id: task run identifier on remote tes service.
+        user: User name for basic authentication.
+        password: Password for basic authentication.
 
     Returns:
         Task identifier.
@@ -71,7 +76,12 @@ def task__track_task_progress(
 
     # fetch task log and upsert database document
     try:
-        cli = tes.HTTPClient(url, timeout=5)
+        cli = tes.HTTPClient(
+            url,
+            timeout=5,
+            user=user,
+            password=password,
+        )
         response = cli.get_task(task_id=remote_task_id)
     except Exception:
         db_client.update_task_state(state=TesState.SYSTEM_ERROR.value)

--- a/pro_tes/tasks/track_task_progress.py
+++ b/pro_tes/tasks/track_task_progress.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
     ignore_result=True,
     track_started=True,
 )
-def task__track_task_progress(
+def task__track_task_progress(  # pylint: disable=too-many-arguments
     self,  # pylint: disable=unused-argument
     worker_id: str,
     remote_host: str,


### PR DESCRIPTION
* add support for basic auth credentials for requests to TES instances
* fix bug in enum serialization; now use values for all enums in all models
* add handler for basic auth input/output URLs; if not forwarding to Funnel instances, basic auth credentials are stripped from such URLs