### PR TITLE
fix: call middleware in task creation class

### DIFF
--- a/pro_tes/ga4gh/tes/server.py
+++ b/pro_tes/ga4gh/tes/server.py
@@ -8,7 +8,6 @@ from foca.utils.logging import log_traffic
 
 from pro_tes.ga4gh.tes.service_info import ServiceInfo
 from pro_tes.ga4gh.tes.task_runs import TaskRuns
-from pro_tes.middleware.middleware import TaskDistributionMiddleware
 
 # pragma pylint: disable=invalid-name,unused-argument
 
@@ -42,12 +41,8 @@ def CreateTask(*args, **kwargs) -> Dict:
         *args: Variable length argument list.
         **kwargs: Arbitrary keyword arguments.
     """
-    task_distributor = TaskDistributionMiddleware()
-    requests, start_time = task_distributor.modify_request(request=request)
     task_runs = TaskRuns()
-    response = task_runs.create_task(
-        request=requests, start_time=start_time, **kwargs
-    )
+    response = task_runs.create_task(request=request, **kwargs)
     return response
 
 

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -71,9 +71,9 @@ class TaskRuns:
         Returns:
             Task identifier.
         """
+        start_time = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
         payload: Dict = deepcopy(request.json)
         db_document: DbDocument = DbDocument()
-        start_time = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
 
         db_document.basic_auth = self.parse_basic_auth(request.authorization)
 
@@ -114,7 +114,6 @@ class TaskRuns:
             ) from exc
 
         for tes_uri in tes_uri_list:
-
             db_document.tes_endpoint = TesEndpoint(host=tes_uri)
             url: str = (
                 f"{db_document.tes_endpoint.host.rstrip('/')}/"

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -66,8 +66,7 @@ class TaskRuns:
         """Start task.
 
         Args:
-            **kwargs: Additional keyword arguments passed along with
-                             request.
+            **kwargs: Additional keyword arguments passed along with request.
         Returns:
             Task identifier.
         """

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -29,6 +29,7 @@ from pro_tes.ga4gh.tes.models import (
     TesNextTes,
 )
 from pro_tes.ga4gh.tes.states import States
+from pro_tes.middleware.middleware import TaskDistributionMiddleware
 from pro_tes.tasks.track_task_progress import task__track_task_progress
 from pro_tes.utils.db import DbDocumentConnector
 from pro_tes.utils.models import TaskModelConverter
@@ -57,6 +58,7 @@ class TaskRuns:
             self.foca_config.db.dbs["taskStore"].collections["tasks"].client
         )
         self.store_logs = self.foca_config.storeLogs["execution_trace"]
+        self.task_distributor = TaskDistributionMiddleware()
 
     def create_task(  # pylint: disable=too-many-statements,too-many-branches
         self, **kwargs
@@ -74,13 +76,22 @@ class TaskRuns:
 
         db_document.basic_auth = self.parse_basic_auth(request.authorization)
 
-        tes_uri_list = deepcopy(payload["tes_uri"])
-        del payload["tes_uri"]
-
         db_document.task_outgoing = TesTask(**payload)
+
+        # middleware is called after the task is created in the database
+        payload = self.task_distributor.modify_request(request=request).json
+
+        tes_uri_list = deepcopy(payload["tes_uri"])
+        start_time = deepcopy(payload["start_time"])
+        del payload["tes_uri"]
+        del payload["start_time"]
+
         db_document.task_incoming = TesTask(**payload)
         db_document = self._update_task_incoming(
-            payload=payload, db_document=db_document, **kwargs
+            payload=payload,
+            db_document=db_document,
+            start_time=start_time,
+            **kwargs,
         )
         logger.info(
             "Trying to forward incoming task with task identifier "
@@ -444,11 +455,11 @@ class TaskRuns:
         return projection
 
     def _update_task_incoming(
-        self, payload: dict, db_document: DbDocument, **kwargs
+        self, payload: dict, db_document: DbDocument, start_time: str, **kwargs
     ) -> DbDocument:
         """Update the task incoming object."""
         logs = self._set_logs(
-            payloads=deepcopy(payload), start_time=kwargs["start_time"]
+            payloads=deepcopy(payload), start_time=start_time
         )
         db_document.task_incoming.logs = [TesTaskLog(**logs) for logs in logs]
         db_document.task_incoming.state = TesState.UNKNOWN

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -67,12 +67,13 @@ class TaskRuns:
 
         Args:
             **kwargs: Additional keyword arguments passed along with
-                             request and start_time.
+                             request.
         Returns:
             Task identifier.
         """
         payload: Dict = deepcopy(request.json)
         db_document: DbDocument = DbDocument()
+        start_time = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
 
         db_document.basic_auth = self.parse_basic_auth(request.authorization)
 
@@ -82,9 +83,7 @@ class TaskRuns:
         payload = self.task_distributor.modify_request(request=request).json
 
         tes_uri_list = deepcopy(payload["tes_uri"])
-        start_time = deepcopy(payload["start_time"])
         del payload["tes_uri"]
-        del payload["start_time"]
 
         db_document.task_incoming = TesTask(**payload)
         db_document = self._update_task_incoming(

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -67,6 +67,7 @@ class TaskRuns:
 
         Args:
             **kwargs: Additional keyword arguments passed along with request.
+
         Returns:
             Task identifier.
         """

--- a/pro_tes/middleware/middleware.py
+++ b/pro_tes/middleware/middleware.py
@@ -46,8 +46,6 @@ class TaskDistributionMiddleware(AbstractMiddleware):
                     self.input_uris.append(
                         request.json["inputs"][index]["url"]
                     )
-                else:
-                    continue
 
         if len(self.input_uris) != 0:
             self.tes_uris = distance.task_distribution(self.input_uris)
@@ -58,4 +56,5 @@ class TaskDistributionMiddleware(AbstractMiddleware):
             request.json["tes_uri"] = self.tes_uris
         else:
             raise Exception  # pylint: disable=broad-exception-raised
-        return request, start_time
+        request.json["start_time"] = start_time
+        return request

--- a/pro_tes/middleware/middleware.py
+++ b/pro_tes/middleware/middleware.py
@@ -1,7 +1,6 @@
 """Middleware to inject into TES requests."""
 
 import abc
-from datetime import datetime
 from typing import List
 
 from pro_tes.middleware.task_distribution import distance, random
@@ -36,9 +35,8 @@ class TaskDistributionMiddleware(AbstractMiddleware):
             request: Incoming request object.
 
         Returns:
-            Tuple of modified request object and start time.
+            Tuple of modified request object.
         """
-        start_time = datetime.now().strftime("%m-%d-%Y %H:%M:%S")
 
         if "inputs" in request.json.keys():
             for index in range(len(request.json["inputs"])):
@@ -56,5 +54,4 @@ class TaskDistributionMiddleware(AbstractMiddleware):
             request.json["tes_uri"] = self.tes_uris
         else:
             raise Exception  # pylint: disable=broad-exception-raised
-        request.json["start_time"] = start_time
         return request

--- a/pro_tes/middleware/middleware.py
+++ b/pro_tes/middleware/middleware.py
@@ -37,7 +37,6 @@ class TaskDistributionMiddleware(AbstractMiddleware):
         Returns:
             Tuple of modified request object.
         """
-
         if "inputs" in request.json.keys():
             for index in range(len(request.json["inputs"])):
                 if "url" in request.json["inputs"][index].keys():


### PR DESCRIPTION
- fix #132 by calling middleware in `pro_tes.ga4gh.tes.task_runs.TaskRuns` class rather than the upstream `pro_tes.ga4gh.tes.server.CreateTask()` controller
- the incoming request is now stored in the database before being modified by any middleware

