### PR TITLE
fix: premature system error state

### DIFF
--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -209,9 +209,12 @@ class TaskRuns:
             )
             return {"id": db_document.task.id}
 
-        # No suitable TES instance found. Task state set to 'SYSTEM_ERROR'.
         db_connector.update_task_state(
             state=TesState.SYSTEM_ERROR.value
+        )
+        logger.error(
+            "No suitable TES instance found. Task state set to "
+            "'SYSTEM_ERROR'."
         )
 
     def list_tasks(self, **kwargs) -> Dict:

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -209,7 +209,7 @@ class TaskRuns:
             )
             return {"id": db_document.task_incoming.id}
 
-        # set TES state to SYSTEM_ERROR as task submission failed on all the available TES instances.
+        # No suitable TES instance found. Task state set to 'SYSTEM_ERROR'.
         db_connector.update_task_state(
             state=TesState.SYSTEM_ERROR.value
         )

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -127,9 +127,7 @@ class TaskRuns:
                     password=db_document.basic_auth.password,
                 )
             except ValueError as exc:
-                db_connector.update_task_state(
-                    state=TesState.SYSTEM_ERROR.value
-                )
+
                 logger.info(
                     f"Task '{db_document.task_incoming.id}' could not "
                     f"be sentto TES endpoint hosted at: {url}. Invalid TES"
@@ -157,9 +155,7 @@ class TaskRuns:
             try:
                 remote_task_id = cli.create_task(payload_marshalled)
             except requests.HTTPError as exc:
-                db_connector.update_task_state(
-                    state=TesState.SYSTEM_ERROR.value
-                )
+
                 logger.info(
                     f"Task '{db_document.task_incoming.id}' "
                     "could not be sent to TES endpoint hosted "
@@ -212,6 +208,11 @@ class TaskRuns:
                 },
             )
             return {"id": db_document.task_incoming.id}
+
+        # set TES state to SYSTEM_ERROR as task submission failed on all the available TES instances.
+        db_connector.update_task_state(
+            state=TesState.SYSTEM_ERROR.value
+        )
 
     def list_tasks(self, **kwargs) -> Dict:
         """Return list of tasks.


### PR DESCRIPTION
**IMPORTANT: Please create an issue before filing a pull request! Changes need to be discussed before proceeding. Please read the [contribution guidelines](CONTRIBUTING.md).**

**Details**

Resolves #139 

When submission of the task to the best TES instance fails the state is set to SYSTEM_ERROR.Ideally, it should not set the state to SYSTEM_ERROR until the task submission fails on all the available TES instances.

To solve this, I _moved the code-block_ which was specifically related to setting the error state to `SYSTEM ERROR` to the place  which will only be touched if all the TES instances fail. But for every failed instance, a message will be logged.

**Testing**

NA

**Documentation**

NA

**Style**

My code adheres to coding convention of this project.

**Closing issues**

closes issue: #139 

