### PR TITLE
feat: filter tasks by name prefix

### DIFF
--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -240,6 +240,13 @@ class TaskRuns:
         view = kwargs.get("view", "BASIC")
         projection = self._set_projection(view=view)
 
+        name_prefix = kwargs.get("name_prefix")
+
+        if name_prefix is not None:
+            filter_dict["task_original.name"] = {
+                "$regex": f"^{name_prefix}"
+            }
+
         cursor = (
             self.db_client.find(filter=filter_dict, projection=projection)
             .sort("_id", -1)

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -240,7 +240,7 @@ class TaskRuns:
         view = kwargs.get("view", "BASIC")
         projection = self._set_projection(view=view)
 
-        name_prefix = kwargs.get("name_prefix")
+        name_prefix: str = kwargs.get("name_prefix")
 
         if name_prefix is not None:
             filter_dict["task_original.name"] = {


### PR DESCRIPTION
**IMPORTANT: Please create an issue before filing a pull request! Changes need to be discussed before proceeding. Please read the [contribution guidelines](CONTRIBUTING.md).**

**Details**

Solves issue #127

Currently, when name_prefix is passed as a parameter with `\task` route, the tasks aren't filtered. This PR involves adding a wildcard regular expression matching and filtering of tasks with respect to name_prefix (if present).
**Note** : 
Filtering is strongly **case sensitive**. 
Therefore, if name_prefix="Foo" then tasks with their names starting with "Foo such as Foo1, Foo2 (Foo*) will be considered but (foo, FOo, etc.) wont be considered.

**Testing**
NA

**Documentation**
NA

**Style**

Code adheres to styling of the project.

**Closing issues**

Closes #127 

**Credit**

Add your credentials to the [list of contributors](contributors.md) once your pull request was merged.
