### PR TITLE
auth: add bearer auth security scheme

### DIFF
--- a/pro_tes/api/security_schemes.yaml
+++ b/pro_tes/api/security_schemes.yaml
@@ -1,0 +1,6 @@
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/pro_tes/config.yaml
+++ b/pro_tes/config.yaml
@@ -62,7 +62,7 @@ api:
           - bearerAuth: []
       add_security_fields:
         x-bearerInfoFunc: foca.security.auth.validate_token
-      disable_auth: False
+      disable_auth: True
       connexion:
         strict_validation: True
         # current specs have inconsistency, therefore disabling response validation

--- a/pro_tes/config.yaml
+++ b/pro_tes/config.yaml
@@ -55,11 +55,14 @@ api:
     - path:
         - api/9e9c5aa.task_execution_service.openapi.yaml
         - api/additional_logs.yaml
+        - api/security_schemes.yaml
       add_operation_fields:
         x-openapi-router-controller: ga4gh.tes.server
+        security:
+          - bearerAuth: []
       add_security_fields:
         x-bearerInfoFunc: foca.security.auth.validate_token
-      disable_auth: True
+      disable_auth: False
       connexion:
         strict_validation: True
         # current specs have inconsistency, therefore disabling response validation


### PR DESCRIPTION
**Details**

- Add OpenAPI file with `securitySchemes` definition for bearer token authentication.
- Update app configuration in `pro_tes/config.yaml` to apply the security schema to all endpoints. Authentication is disabled by default in order to allow current tests to pass; enable it by setting `disable_auth` to `False`.

**Closing issues**

Closes #162
