### PR TITLE
fix: query filter in list task endpoint

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - "5672:5672"
 
   mongodb:
-    image: mongo:3.2
+    image: mongo:3.6
     restart: unless-stopped
     volumes:
       - ${PROTES_DATA_DIR:-../data/pro_tes}/db:/data/db

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -284,7 +284,6 @@ class TaskRuns:
 
         name_prefix = kwargs.get("name_prefix")
         if name_prefix is not None:
-            name_prefix: str = str(name_prefix)
             filter_dict["task_original.name"] = {"$regex": f"^{name_prefix}"}
 
         cursor = (

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -272,16 +272,19 @@ class TaskRuns:
         )
         page_token = kwargs.get("page_token")
         filter_dict = {}
-        filter_dict["user_id"] = kwargs.get("user_id")
+
+        user_id = kwargs.get("user_id")
+        if user_id is not None:
+            filter_dict["user_id"] = user_id
 
         if page_token is not None:
             filter_dict["_id"] = {"$lt": ObjectId(page_token)}
         view = kwargs.get("view", "BASIC")
         projection = self._set_projection(view=view)
 
-        name_prefix: str = str(kwargs.get("name_prefix"))
-
+        name_prefix = kwargs.get("name_prefix")
         if name_prefix is not None:
+            name_prefix: str = str(name_prefix)
             filter_dict["task_original.name"] = {"$regex": f"^{name_prefix}"}
 
         cursor = (

--- a/pro_tes/ga4gh/tes/task_runs.py
+++ b/pro_tes/ga4gh/tes/task_runs.py
@@ -439,7 +439,7 @@ class TaskRuns:
             )
             document.worker_id = uuid()
             try:
-                self.db_client.insert(document.dict(exclude_none=True))
+                self.db_client.insert_one(document.dict(exclude_none=True))
             except DuplicateKeyError:
                 continue
             assert document is not None

--- a/pro_tes/utils/db.py
+++ b/pro_tes/utils/db.py
@@ -105,9 +105,7 @@ class DbDocumentConnector:
         if projection is None:
             projection = {"_id": False}
         document_unvalidated = self.collection.find_one_and_update(
-            {
-                "worker_id": self.worker_id
-            },
+            {"worker_id": self.worker_id},
             {
                 "$set": {
                     ".".join([root, key]): value for (key, value) in

--- a/pro_tes/utils/db.py
+++ b/pro_tes/utils/db.py
@@ -2,9 +2,7 @@
 
 import logging
 from typing import Mapping, Optional
-from pymongo.collection import ReturnDocument  # type: ignore
-from pymongo import collection as Collection  # type: ignore
-
+from pymongo.collection import ReturnDocument, Collection
 from pro_tes.ga4gh.tes.models import DbDocument, TesState
 
 logger = logging.getLogger(__name__)
@@ -23,17 +21,17 @@ class DbDocumentConnector:
     """
 
     def __init__(
-            self,
-            collection: Collection,  # type: ignore
-            worker_id: str,
+        self,
+        collection: Collection,
+        worker_id: str,
     ) -> None:
         """Construct object instance."""
-        self.collection: Collection = collection  # type: ignore
+        self.collection: Collection = collection
         self.worker_id: str = worker_id
 
     def get_document(
-            self,
-            projection: Optional[Mapping] = None,
+        self,
+        projection: Optional[Mapping] = None,
     ) -> DbDocument:
         """Get document associated with task.
 
@@ -51,12 +49,12 @@ class DbDocumentConnector:
         """
         if projection is None:
             projection = {"_id": False}
-        document_unvalidated = self.collection.find_one(  # type: ignore
+        document_unvalidated = self.collection.find_one(
             filter={"worker_id": self.worker_id},
             projection=projection,
         )
         try:
-            document: DbDocument = DbDocument(**document_unvalidated)
+            document: DbDocument = DbDocument(**(document_unvalidated or {}))
         except Exception as exc:
             raise ValueError(
                 "Database document does not conform to schema: "
@@ -65,8 +63,8 @@ class DbDocumentConnector:
         return document
 
     def update_task_state(
-            self,
-            state: str = "UNKNOWN",
+        self,
+        state: str = "UNKNOWN",
     ) -> None:
         """Update task status.
 
@@ -80,17 +78,17 @@ class DbDocumentConnector:
             TesState(state)
         except Exception as exc:
             raise ValueError(f"Unknown state: {state}") from exc
-        self.collection.find_one_and_update(  # type: ignore
+        self.collection.find_one_and_update(
             {"worker_id": self.worker_id},
             {"$set": {"task.state": state}},
         )
         logger.info(f"[{self.worker_id}] {state}")
 
     def upsert_fields_in_root_object(
-            self,
-            root: str,
-            projection: Optional[Mapping] = None,
-            **kwargs: object,
+        self,
+        root: str,
+        projection: Optional[Mapping] = None,
+        **kwargs: object,
     ) -> DbDocument:
         """Insert or update fields in(to) the same root (object) field.
 
@@ -107,7 +105,7 @@ class DbDocumentConnector:
         if projection is None:
             projection = {"_id": False}
         document_unvalidated = (
-            self.collection.find_one_and_update(    # type: ignore
+            self.collection.find_one_and_update(
                 {"worker_id": self.worker_id},
                 {
                     "$set": {

--- a/pro_tes/utils/db.py
+++ b/pro_tes/utils/db.py
@@ -104,18 +104,19 @@ class DbDocumentConnector:
         """
         if projection is None:
             projection = {"_id": False}
-        document_unvalidated = (
-            self.collection.find_one_and_update(
-                {"worker_id": self.worker_id},
-                {
-                    "$set": {
-                        ".".join([root, key]): value
-                        for (key, value) in kwargs.items()
-                    }
-                },
-                projection=projection,
-                return_document=ReturnDocument.AFTER,
-            ))
+        document_unvalidated = self.collection.find_one_and_update(
+            {
+                "worker_id": self.worker_id
+            },
+            {
+                "$set": {
+                    ".".join([root, key]): value for (key, value) in
+                    kwargs.items()
+                }
+            },
+            projection=projection,
+            return_document=ReturnDocument.AFTER,
+        )
         try:
             document: DbDocument = DbDocument(**document_unvalidated)
         except Exception as exc:

--- a/pro_tes/utils/db.py
+++ b/pro_tes/utils/db.py
@@ -23,17 +23,17 @@ class DbDocumentConnector:
     """
 
     def __init__(
-        self,
-        collection: Collection,
-        worker_id: str,
+            self,
+            collection: Collection,  # type: ignore
+            worker_id: str,
     ) -> None:
         """Construct object instance."""
-        self.collection: Collection = collection
+        self.collection: Collection = collection  # type: ignore
         self.worker_id: str = worker_id
 
     def get_document(
-        self,
-        projection: Optional[Mapping] = None,
+            self,
+            projection: Optional[Mapping] = None,
     ) -> DbDocument:
         """Get document associated with task.
 
@@ -51,7 +51,7 @@ class DbDocumentConnector:
         """
         if projection is None:
             projection = {"_id": False}
-        document_unvalidated = self.collection.find_one(
+        document_unvalidated = self.collection.find_one(  # type: ignore
             filter={"worker_id": self.worker_id},
             projection=projection,
         )
@@ -65,8 +65,8 @@ class DbDocumentConnector:
         return document
 
     def update_task_state(
-        self,
-        state: str = "UNKNOWN",
+            self,
+            state: str = "UNKNOWN",
     ) -> None:
         """Update task status.
 
@@ -80,17 +80,17 @@ class DbDocumentConnector:
             TesState(state)
         except Exception as exc:
             raise ValueError(f"Unknown state: {state}") from exc
-        self.collection.find_one_and_update(
+        self.collection.find_one_and_update(  # type: ignore
             {"worker_id": self.worker_id},
             {"$set": {"task.state": state}},
         )
         logger.info(f"[{self.worker_id}] {state}")
 
     def upsert_fields_in_root_object(
-        self,
-        root: str,
-        projection: Optional[Mapping] = None,
-        **kwargs: object,
+            self,
+            root: str,
+            projection: Optional[Mapping] = None,
+            **kwargs: object,
     ) -> DbDocument:
         """Insert or update fields in(to) the same root (object) field.
 
@@ -106,17 +106,18 @@ class DbDocumentConnector:
         """
         if projection is None:
             projection = {"_id": False}
-        document_unvalidated = self.collection.find_one_and_update(
-            {"worker_id": self.worker_id},
-            {
-                "$set": {
-                    ".".join([root, key]): value
-                    for (key, value) in kwargs.items()
-                }
-            },
-            projection=projection,
-            return_document=ReturnDocument.AFTER,
-        )
+        document_unvalidated = (
+            self.collection.find_one_and_update(    # type: ignore
+                {"worker_id": self.worker_id},
+                {
+                    "$set": {
+                        ".".join([root, key]): value
+                        for (key, value) in kwargs.items()
+                    }
+                },
+                projection=projection,
+                return_document=ReturnDocument.AFTER,
+            ))
         try:
             document: DbDocument = DbDocument(**document_unvalidated)
         except Exception as exc:


### PR DESCRIPTION
Fixes #177
Fixes #175 

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the list tasks endpoint by ensuring that 'user_id' and 'name_prefix' filters are only added to the filter dictionary if they are not None.

* **Bug Fixes**:
    - Fixed an issue where the 'user_id' and 'name_prefix' filters in the list tasks endpoint were not properly handling None values.

<!-- Generated by sourcery-ai[bot]: end summary -->